### PR TITLE
Fixed part of macos arm build process.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,8 @@ rich = "*"
 requests-cache = "*"
 pyinstaller = "*"
 numpy = "*"
+macholib = "*"
+cattrs = "*"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -19,6 +19,7 @@ python_version = "3.10"
 
 [scripts]
 build = "./devtools/build.sh"
+build_macos = "./devtools/build_macos.sh"
 build_windows = "./devtools/build_windows.sh"
 cfscripts = "python ./src/main.py"
 comuaccount = "python ./src/scripts/ComuACCount/main.py"

--- a/devtools/build_macos.sh
+++ b/devtools/build_macos.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+mkdir -p ./bin ./_dist ./_specs ./_build
+
+BIN=$(realpath ./bin)
+DIST=$(realpath ./_dist)
+SPECS=$(realpath ./_specs)
+BUILD=$(realpath ./_build)
+
+function pyinstall {
+    pyinstaller --distpath $DIST --workpath $BUILD --specpath $SPECS -F -p ./src $@
+}
+
+function python_build {
+    pyinstall -n $1 src/scripts/$2
+}
+
+# scripts linux
+python_build dailyacs DailyACs/main.py
+python_build comuaccount ComuACCount/main.py
+python_build rangerank RangeRank/main.py
+python_build virtualperformance VirtualPerformance/main.py
+python_build unsolvedcontestproblems UnsolvedContestProblems/main.py
+python_build whatif WhatIf/main.py
+
+# cfscripts linux
+pyinstall -n cfscripts ./src/main.py
+cp $DIST/cfscripts $BIN/cfscripts


### PR DESCRIPTION
Fiexed the realpath args issue. Still some missing packages errors when running executable (attrs).
Steps to reproduce:
pipenv run build_macos
./bin/cfscripts
>(press 5 for virtual performance)
>enter any name
ERROR:
`Dependencies are not installed for this feature
Unable to deserialize response: No module named 'cattr'
Dependencies are not installed for this feature
Traceback (most recent call last):
  File "main.py", line 117, in <module>
  File "main.py", line 113, in main
  File "main.py", line 25, in virtualperformance
  File "scripts/VirtualPerformance/main.py", line 68, in main
  File "lib/contests.py", line 12, in get_contest_map
  File "lib/contests.py", line 9, in get_contests
  File "lib/api.py", line 40, in get_results
  File "requests_cache/session.py", line 127, in get
  File "requests_cache/session.py", line 183, in request
  File "requests/sessions.py", line 589, in request
  File "requests_cache/session.py", line 230, in send
  File "requests_cache/session.py", line 258, in _send_and_cache
  File "requests_cache/backends/base.py", line 100, in save_response
  File "requests_cache/backends/filesystem.py", line 116, in __setitem__
  File "requests_cache/backends/base.py", line 343, in serialize
  File "requests_cache/serializers/pipeline.py", line 56, in dumps
  File "requests_cache/_utils.py", line 59, in dumps
  File "requests_cache/_utils.py", line 52, in _log_error
  File "requests_cache/backends/base.py", line 357, in deserialize
  File "requests_cache/serializers/pipeline.py", line 61, in loads
  File "requests_cache/_utils.py", line 62, in loads
  File "requests_cache/_utils.py", line 52, in _log_error
  File "requests_cache/serializers/preconf.py", line 20, in make_stage
  File "importlib/__init__.py", line 126, in import_module
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'cattr'
[PYI-76530:ERROR] Failed to execute script 'main' due to unhandled exception!`